### PR TITLE
🔄 Refactor: svg 아이콘 리액트 컴포넌트화

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "axios": "^1.7.9",
+    "lucide-react": "^0.475.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.1.5",

--- a/src/assets/icons/Icon.tsx
+++ b/src/assets/icons/Icon.tsx
@@ -1,0 +1,27 @@
+import { icons } from "lucide-react";
+import { HTMLAttributes } from "react";
+
+export interface IconProps extends HTMLAttributes<HTMLOrSVGElement> {
+  name: keyof typeof icons;
+  size?: number;
+  strokeWidth?: number;
+}
+
+export default function Icon({
+  name,
+  size,
+  strokeWidth,
+  className,
+  ...props
+}: IconProps) {
+  const SelectIcon = icons[name];
+
+  return (
+    <SelectIcon
+      size={size}
+      strokeWidth={strokeWidth}
+      className={className}
+      {...props}
+    />
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2100,6 +2100,11 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
+lucide-react@^0.475.0:
+  version "0.475.0"
+  resolved "https://registry.yarnpkg.com/lucide-react/-/lucide-react-0.475.0.tgz#4b7b62c024f153ee4b52a6a0f33f9e72f07156f0"
+  integrity sha512-NJzvVu1HwFVeZ+Gwq2q00KygM1aBhy/ZrhY9FsAgJtpB+E4R7uxRk9M2iKvHa6/vNxZydIB59htha4c2vvwvVg==
+
 math-intrinsics@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> refactor: SVG 아이콘 컴포넌트화 #23  

## 📝 작업 내용

>프로젝트에 사용되는 아이콘 컴포넌화 했습니다. 
>  props로 아이콘의 크기, 아이콘굵기, className으로 스타일가이드에서 지정한 색상명들 사용할 수 있게 했습니다.

## 📌 그외

>  pull 받으시고 yarn add lucide-react 한번 해주세요! 
>  코드 작성후 test 해본 코드 같이 이미지 첨부하니 보시고 아이콘 적용된거 바꿔주시고 아이콘 따로 저장되어있는 파일은 삭제해주시면 될듯합니다!

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/d6cacfb2-05fa-416a-af96-ca6c6a2a3454)
