### PR TITLE
🎨 style: 헤더 퍼블리싱 및 헤더 로고 관련 폰트 추가

### DIFF
--- a/src/components/notification/notification.tsx
+++ b/src/components/notification/notification.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function notification() {
+  return <div>notification</div>;
+}

--- a/src/css/typography.css
+++ b/src/css/typography.css
@@ -1,4 +1,10 @@
 @layer base {
+  .logo {
+    font-size: 50px;
+    font-weight: 400;
+    /* line-height: 65px; */
+  }
+
   .h1-b {
     font-size: 32px;
     font-weight: 700;

--- a/src/layouts/Header.tsx
+++ b/src/layouts/Header.tsx
@@ -1,10 +1,37 @@
+import { useState } from "react";
+import Icon from "../assets/icons/Icon";
+
 const Header = () => {
+  const [showNotification, setShowNotification] = useState(false);
+  const [toggleSidebar, setToggleSidebar] = useState(false);
+  const handleNotificationClick = () => {
+    setShowNotification(true);
+  };
+  const handleToggleSidebarClick = () => {
+    setToggleSidebar(!toggleSidebar);
+  };
   return (
-    <div className="w-full h-[84px] bg-blue-7 fixed flex items-center px-6 z-10">
-      <h1 className="font-serif italic text-blue-1 mx-10 text-3xl ">
-        On culture
-      </h1>
-    </div>
+    <header className="w-full h-[84px] top-0 left-0 fixed px-10 py-[21px] z-10 bg-blue-7  ">
+      <div className="max-w-[1200px] mx-auto flex justify-between items-center">
+        <a href="/" aria-label="홈페이지로 이동">
+          <h1 className="font-dm italic text-blue-1 text-2xl/[38px]">
+            On culture
+          </h1>
+        </a>
+        <div className="flex gap-4">
+          <button onClick={handleNotificationClick} aria-label="알림 열기">
+            <Icon name="Bell" size={24} className="text-blue-1" />
+          </button>
+          <button onClick={handleToggleSidebarClick} aria-label="메뉴 열기">
+            {toggleSidebar === true ? (
+              <Icon name="X" size={24} className="text-blue-1" />
+            ) : (
+              <Icon name="Menu" size={24} className="text-blue-1" />
+            )}
+          </button>
+        </div>
+      </div>
+    </header>
   );
 };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #25 

## 📝 작업 내용

> 헤더영역 퍼블리싱했습니다.
> 로고 폰트 typograghy.css에 설정해두었습니다.

## 📌 그외

>

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/39d9393b-7a02-4dd6-85d2-68dd1dda3987)
![image](https://github.com/user-attachments/assets/7b04583f-b9b8-4155-b1a3-7c50b61419a2)

