### PR TITLE
🐛 Fix: 선호 분야 아이콘 색상 지정

### DIFF
--- a/src/components/ui/InterestsIcon.tsx
+++ b/src/components/ui/InterestsIcon.tsx
@@ -3,7 +3,6 @@ import React from "react";
 interface InterestsIconProps {
   name: string;
   isActive?: boolean;
-  color: string;
   onClick?: () => void;
   disabled?: boolean;
   as?: "div" | "button";
@@ -12,12 +11,22 @@ interface InterestsIconProps {
 const InterestsIcon = ({
   name,
   isActive = false,
-  color,
   onClick,
   disabled = false,
   as = "button", // 기본값 button
 }: InterestsIconProps) => {
   const Component = as === "button" ? "button" : "div"; // 조건에 따라 컴포넌트 결정
+
+  const colorMapping: { [key: string]: string } = {
+    "팝업 스토어": "#f28c50",
+    전시회: "#6d8294",
+    뮤지컬: "#a370d8",
+    연극: "#ebcb3d",
+    페스티벌: "#4dbd79",
+    콘서트: "#5e7fe2",
+  };
+
+  const color = colorMapping[name] || "#000"; // 매핑된 색상 또는 기본 색상
 
   // 문자열 템플릿 대신 객체 형태로 스타일 정의
   const getStyles = () => {

--- a/src/pages/user/ProfileEdit.tsx
+++ b/src/pages/user/ProfileEdit.tsx
@@ -560,68 +560,62 @@ const ProfileEdit = () => {
                     <InterestsIcon
                       name="팝업 스토어"
                       isActive={activeButtons.includes("팝업 스토어")}
-                      color="#f28c50"
                       onClick={() => toggleButton("팝업 스토어")}
                       disabled={
                         activeButtons.length >= 3 &&
                         !activeButtons.includes("팝업 스토어")
                       }
-                      as="button"
+                      as="button" // button 태그로 사용
                     />
                     <InterestsIcon
                       name="전시회"
                       isActive={activeButtons.includes("전시회")}
-                      color="#6d8294"
                       onClick={() => toggleButton("전시회")}
                       disabled={
                         activeButtons.length >= 3 &&
                         !activeButtons.includes("전시회")
                       }
-                      as="button"
+                      as="button" // button 태그로 사용
                     />
                     <InterestsIcon
                       name="뮤지컬"
                       isActive={activeButtons.includes("뮤지컬")}
-                      color="#a370d8"
                       onClick={() => toggleButton("뮤지컬")}
                       disabled={
                         activeButtons.length >= 3 &&
                         !activeButtons.includes("뮤지컬")
                       }
-                      as="button"
+                      as="button" // button 태그로 사용
                     />
                     <InterestsIcon
                       name="연극"
                       isActive={activeButtons.includes("연극")}
-                      color="#ebcb3d"
                       onClick={() => toggleButton("연극")}
                       disabled={
                         activeButtons.length >= 3 &&
                         !activeButtons.includes("연극")
                       }
-                      as="button"
+                      as="button" // button 태그로 사용
                     />
                     <InterestsIcon
                       name="페스티벌"
                       isActive={activeButtons.includes("페스티벌")}
-                      color="#4dbd79"
                       onClick={() => toggleButton("페스티벌")}
                       disabled={
                         activeButtons.length >= 3 &&
                         !activeButtons.includes("페스티벌")
                       }
-                      as="button"
+                      as="button" // button 태그로 사용
                     />
                     <InterestsIcon
                       name="콘서트"
                       isActive={activeButtons.includes("콘서트")}
-                      color="#5e7fe2"
                       onClick={() => toggleButton("콘서트")}
                       disabled={
                         activeButtons.length >= 3 &&
                         !activeButtons.includes("콘서트")
                       }
-                      as="button"
+                      as="button" // button 태그로 사용
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호

## 📝 작업 내용

> InterestIcon 컴포넌트 선호 분야 아이콘 색상 지정

## ✅ InterestsIcon.tsx (선호 분야 아이콘 컴포넌트) 사용법
-  as="div"
`````tsx
<InterestsIcon
          name="Example Div"
          as="div" // div 태그로 사용
/>
``````

- as="button"
`````tsx
<InterestsIcon
          name="팝업 스토어"
          isActive={activeButtons.includes("팝업 스토어")}
          onClick={() => toggleButton("팝업 스토어")}
          disabled={
            activeButtons.length >= 3 && !activeButtons.includes("팝업 스토어")
          }
          as="button" // button 태그로 사용
/>
``````

## 📌 그외

>

## 📸 스크린샷 (선택)
