### PR TITLE
✨ feature: 포스트카드 회원여부 확인로직 구현 및 비회원 좋아요 클릭시 로그인 유도 모달 띄우기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,20 @@
 import { BrowserRouter } from "react-router-dom";
 import Router from "./routes/Router";
+import Modal from "./components/ui/Modal";
+import { useAuthStore } from "./stores/authStore";
+import { useEffect } from "react";
 
 function App() {
+  const { checkAuth } = useAuthStore();
+
+  useEffect(() => {
+    checkAuth();
+  }, []);
+
   return (
     <BrowserRouter>
       <Router />
+      <Modal />
     </BrowserRouter>
   );
 }

--- a/src/components/common/PostCard.tsx
+++ b/src/components/common/PostCard.tsx
@@ -4,6 +4,8 @@ import { useNavigate } from "react-router-dom";
 import { formatDate } from "../../utils/dateUtils";
 import { PostCardProps } from "../../types/post";
 import { useLikeState } from "../../hooks/useLikeState";
+import { useAuthStore } from "../../stores/authStore";
+import { useModalStore } from "../../stores/modalStore";
 
 const PostCard: React.FC<PostCardProps> = ({ post, onLikeToggle }) => {
   const { isLiked, likeCount, toggleLike } = useLikeState(
@@ -13,9 +15,22 @@ const PostCard: React.FC<PostCardProps> = ({ post, onLikeToggle }) => {
   );
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
+  const { isLoggedIn, checkAuth } = useAuthStore();
+  const { openModal } = useModalStore();
 
   const handleToggleLike = async (e: React.MouseEvent) => {
     e.stopPropagation();
+    await checkAuth();
+    const isLoggedIn = localStorage.getItem("isLoggedIn") === "true";
+    if (!isLoggedIn) {
+      openModal(
+        "로그인이 필요한 서비스입니다.\n 로그인 하러 가시겠어요?",
+        "취소하기",
+        "로그인하기",
+        () => navigate("/login")
+      );
+      return;
+    }
     setIsLoading(true);
     const result = await toggleLike();
     if (result && result.success) {

--- a/src/stores/modalStore.ts
+++ b/src/stores/modalStore.ts
@@ -16,7 +16,7 @@ interface ModalState {
 }
 
 export const useModalStore = create<ModalState>((set) => ({
-  isOpen: true,
+  isOpen: false,
   text: "",
   cancelText: "취소하기",
   confirmText: "삭제하기",


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #110 

## 📝 작업 내용

> 포스트카드에서 회원여부 확인하는 로직 구현했습니다.
> 비회원이 좋아요 클릭시 로그인 유도 모달 띄워지게 구현했습니다.

## 📌 그외

> 새로고침을 하거나 다른페이지로 이동했을때 모달컴포넌트가 띄워지는 현상이 있어 modalStore의 isOpen의 값을 false로 처리했습니다

## 📸 스크린샷 (선택)
