### PR TITLE
🐛 Fix: 프로필 이미지 에러 수정

### DIFF
--- a/src/components/common/PostCard.tsx
+++ b/src/components/common/PostCard.tsx
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import Icon from "../../assets/icons/Icon";
 import { useNavigate } from "react-router-dom";
 import { formatDate } from "../../utils/dateUtils";
-import { PostCardProps } from "../../types/post";
+import { PostCardProps } from "../../types/Post";
 import { useLikeState } from "../../hooks/useLikeState";
 import { useAuthStore } from "../../stores/authStore";
 import { useModalStore } from "../../stores/modalStore";

--- a/src/components/common/ProfileHeader.tsx
+++ b/src/components/common/ProfileHeader.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import Icon from "../../assets/icons/Icon";
-import { UserData } from "../../types/user";
+import { UserData } from "../../types/User";
 import InterestsIcon from "../ui/InterestsIcon";
 
 const ProfileHeader = ({

--- a/src/hooks/useEventData.ts
+++ b/src/hooks/useEventData.ts
@@ -30,6 +30,5 @@ export const useAllEventData = () => {
 
     fetchAllData();
   }, []);
-  console.log(data);
   return { data, loading };
 };

--- a/src/layouts/Sidebar/Sidebar.tsx
+++ b/src/layouts/Sidebar/Sidebar.tsx
@@ -15,13 +15,16 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
     const { logout, checkAuth, isLoggedIn, user } = useAuthStore();
 
     useEffect(() => {
-      checkAuth();
-    }, [checkAuth]);
+      if (isOpen) {
+        checkAuth();
+      }
+    }, [isOpen]);
 
     const handleLogout = async () => {
       await logout();
     };
 
+    console.log(user);
     return (
       <aside
         ref={ref}
@@ -55,7 +58,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
                   <div className="flex items-center gap-2">
                     <div className="w-[50px] h-[50px] rounded-full overflow-hidden userProfile-shadow">
                       <img
-                        src={user?.profileImage || "/default-image.png"}
+                        src={user?.s3Bucket || "/default-image.png"}
                         className="w-full h-full object-cover bg-center"
                         alt="유저 프로필 이미지"
                       />

--- a/src/pages/user/MyPage.tsx
+++ b/src/pages/user/MyPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import api from "../../api/api";
 import ScrollToTopButton from "../../components/ui/ScrollToTopButton";
 import ProfileHeader from "../../components/common/ProfileHeader";
-import { UserData } from "../../types/user";
+import { UserData } from "../../types/User";
 import PostCard from "../../components/common/PostCard";
 import { PostCardProps } from "../../types/Post";
 import { TabNavigation } from "../../components/ui/TabNavigation";
@@ -95,6 +95,8 @@ const MyPage = () => {
             {bookmarkData.length > 0 ? (
               bookmarkData.map((post) => (
                 <InformationCard
+                  id={post.id}
+                  category={post.genre}
                   key={post.id}
                   imageUrl={post.postUrl}
                   title={post.title}
@@ -113,6 +115,8 @@ const MyPage = () => {
     }
   };
 
+  console.log(userData);
+  console.log(bookmarkData);
   return (
     <div className="w-full flex flex-col mx-auto">
       <div className="mt-[108px] max-w-[1280px] mx-auto p-6">
@@ -121,7 +125,7 @@ const MyPage = () => {
             nickname={userData.nickname}
             description={userData.description}
             interests={userData.interests}
-            profileImage={userData.profileImage}
+            profileImage={userData.s3Bucket}
             isMyPage={true}
           />
         )}

--- a/src/pages/user/UserPage.tsx
+++ b/src/pages/user/UserPage.tsx
@@ -3,9 +3,9 @@ import PostCard from "../../components/common/PostCard";
 import ProfileHeader from "../../components/common/ProfileHeader";
 import ScrollToTopButton from "../../components/ui/ScrollToTopButton";
 import { TitleBar } from "../../components/ui/TitleBar";
-import { PostCardProps } from "../../types/Post";
+import { PostCardProps } from "../../types/post";
 import api from "../../api/api";
-import { UserData } from "../../types/user";
+import { UserData } from "../../types/User";
 import { useParams } from "react-router-dom";
 
 const UserPage = () => {
@@ -46,7 +46,7 @@ const UserPage = () => {
             nickname={userData.nickname}
             description={userData.description}
             interests={userData.interests}
-            profileImage={userData.profileImage}
+            profileImage={userData.s3Bucket}
           />
         )}
         <TitleBar

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -4,6 +4,6 @@ export interface UserData {
   description?: string;
   interests?: string[];
   profileImage?: string;
-  s3Bucket?: string[];
+  s3Bucket?: string;
   isMyPage?: boolean;
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #136 

## 📝 작업 내용

> 프로필 이미지 수정시 재 랜더링 오류 조치 완료 
> 유저페이지, 마이페이지 이미지 불러오는 로직 수정 

## 📌 그외

>

## 📸 스크린샷 (선택)
<img width="1170" alt="Screenshot 2025-03-10 at 11 56 40 AM" src="https://github.com/user-attachments/assets/924fee7f-e677-45c0-920e-d96ba0e64f57" />
<img width="729" alt="Screenshot 2025-03-10 at 11 56 24 AM" src="https://github.com/user-attachments/assets/9db41ee6-4ce9-49c4-964b-c22daa44a447" />

