### PR TITLE
🐛 fix: MapSearch 페이지네이션 중복 코드 수정

### DIFF
--- a/src/pages/mapsearch/MapSearch.tsx
+++ b/src/pages/mapsearch/MapSearch.tsx
@@ -132,17 +132,6 @@ const MapSearch: React.FC = () => {
           />
         </div>
       )}
-
-      {performanceData?.posts && performanceData.posts.length > 0 && (
-        <div className="mb-16">
-          <Pagination
-            totalItems={performanceData?.totalElements || 0}
-            itemsPerPage={9}
-            currentPage={parseInt(searchParams.get("page") || "1")}
-            onPageChange={(page) => updateSearchParams("page", page.toString())}
-          />
-        </div>
-      )}
     </div>
   );
 };


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #161 

## 📝 작업 내용

> mapsearch페이지에 페이지네이션 중복된 부분 코드삭제했습니다.

## 📌 그외

>

## 📸 스크린샷 (선택)
