### PR TITLE
🐛 Fix: 지도검색 페이지 팝업스토어 공연카드 썸네일이 디폴트 이미지로 표시되는 문제 수정

### DIFF
--- a/src/pages/mapsearch/MapSearch.tsx
+++ b/src/pages/mapsearch/MapSearch.tsx
@@ -123,7 +123,7 @@ const MapSearch: React.FC = () => {
       </section>
 
       {performanceData?.posts && performanceData.posts.length > 0 && (
-        <div className="mb-16">
+        <div className="my-20">
           <Pagination
             totalItems={performanceData?.totalElements || 0}
             itemsPerPage={9}

--- a/src/pages/mapsearch/MappageInfomationCardList.tsx
+++ b/src/pages/mapsearch/MappageInfomationCardList.tsx
@@ -33,7 +33,7 @@ const MappageInfomationCardList = ({
                 : post.postUrl
               : Array.isArray(post.postUrl)
                 ? post.postUrl[0]
-                : ""
+                : "/default-image.png"
           }
           startDate={post.startDate} // Pass startDate directly
           endDate={post.endDate} // Pass endDate directly

--- a/src/pages/mapsearch/MappageInfomationCardList.tsx
+++ b/src/pages/mapsearch/MappageInfomationCardList.tsx
@@ -1,7 +1,5 @@
 import InformationCard from "../../components/common/InformationCard";
 import { MapPost } from "../../types/mapSearch";
-// import { useCategoryMapper } from "../../hooks/useInfoCardMapper";
-// import { useDateFormatter } from "../../hooks/useInformationDateFormatter";
 
 interface InformationCardListProps {
   posts?: (MapPost & { isBookmarked: boolean; category: string })[];
@@ -12,9 +10,6 @@ const MappageInfomationCardList = ({
   posts,
   isLoading,
 }: InformationCardListProps) => {
-  // const { mapToApiCategory } = useCategoryMapper();
-  // const { formatDatePeriod } = useDateFormatter();
-
   if (isLoading)
     return <p className="text-center">리스트를 불러오는 중입니다.</p>;
   if (!posts || posts.length === 0)
@@ -27,7 +22,19 @@ const MappageInfomationCardList = ({
           key={post.id}
           id={post.id}
           title={post.title}
-          imageUrl={post.postUrl || "/default-image.png"}
+          imageUrl={
+            typeof post.postUrl === "string"
+              ? post.postUrl.startsWith("[") && post.postUrl.endsWith("]")
+                ? post.postUrl
+                    .slice(1, -1)
+                    .split(",")[0]
+                    .trim()
+                    .replace(/['"]/g, "")
+                : post.postUrl
+              : Array.isArray(post.postUrl)
+                ? post.postUrl[0]
+                : ""
+          }
           startDate={post.startDate} // Pass startDate directly
           endDate={post.endDate} // Pass endDate directly
           location={post.location || "위치 정보 없음"}
@@ -40,4 +47,3 @@ const MappageInfomationCardList = ({
 };
 
 export default MappageInfomationCardList;
-


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #165 

## 📝 작업 내용

> 지도 검색페이지에서 팝없스토어카테고리에서 썸네일 이미지가 디폴트 이미지로만 보였던 부분 수정했습니다.

## 📌 그외

>

## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/c5082802-fdd0-451d-8764-c74c93fd4fa7)