### PR TITLE
🐛 Fix: 상세페이지의 카카오톡 공유하기 내용에 포스터 이미지 수정

### DIFF
--- a/src/components/informationdetail/InfoCardHeader.tsx
+++ b/src/components/informationdetail/InfoCardHeader.tsx
@@ -155,7 +155,7 @@ const InfoCardHeader = ({
           <ShareButton
             url={window.location.href}
             title={showInfo.title}
-            posterUrl={`http://localhost:5173${showInfo.posterUrl}`}
+            posterUrl={showInfo.posterUrl}
           />
         </div>
       </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호

## 📝 작업 내용

> 상세페이지의 카카오톡 공유하기 내용에 포스터 이미지 추가하게 수정

## 📌 그외

>

## 📸 스크린샷 (선택)
