### PR TITLE
style: 소셜커뮤니티 전체 페이지 반응형 작업, 전체레이아웃 마진 및 브레이크포인트 설정

### DIFF
--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -6,7 +6,9 @@ const RootLayout = () => {
     <>
       <Header />
       <main className="w-full max-w-[1280px] mx-auto">
-        <Outlet />
+        <div className="max-xm: mx-4 xm:mx-5 sm:mx-6 md:mx-8 lg:mx-10 xl:mx-12">
+          <Outlet />
+        </div>
       </main>
     </>
   );

--- a/src/pages/community/Community.tsx
+++ b/src/pages/community/Community.tsx
@@ -82,8 +82,8 @@ const Community: React.FC = () => {
 
   return (
     <div className="mt-[168px]">
-      <h2 className="ml-[39px] h1-b">소셜 커뮤니티</h2>
-      <div className="flex items-center justify-end mr-[39px] bg-white">
+      <h2 className="ml-[22px] max-xm:ml-0 h1-b">소셜 커뮤니티</h2>
+      <div className="mr-[22px] max-xm:mr-0 flex items-center justify-end bg-white max-xm:mt-5 xm:mt-5">
         <Dropdown
           data={postCardSortOptionLabels}
           onSelect={handleSortChange}
@@ -91,12 +91,12 @@ const Community: React.FC = () => {
           sizeClassName="w-[114px] h-[30px]"
         />
       </div>
-      <div className="grid grid-cols-3 grid-rows-3 gap-[70px] place-items-center mt-9">
+      <div className=" grid lg:grid-cols-3 sm:grid-cols-2 xm:grid-cols-1 lg:gap-[70px] xm:gap-[35px] max-xm:gap-[35px] max-xm: mb-[82px] place-items-center mt-9">
         {posts.map((post) => (
           <PostCard key={post.id} post={post} onLikeToggle={handleLikeToggle} />
         ))}
       </div>
-      <div className="flex justify-center mt-[104px] mb-[108px]">
+      <div className="sm:flex justify-center mt-[104px] mb-[108px] xm:hidden max-xm:hidden">
         <Pagination
           totalItems={totalItems}
           itemsPerPage={9}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -45,6 +45,17 @@ export default {
       boxShadow: {
         "user-postcard-shadow": "5px 6px 25px 0px rgba(0, 0, 0, 0.1)",
       },
+      screens: {
+        xm: "375px",
+
+        sm: "640px",
+
+        md: "768px",
+
+        lg: "1024px",
+
+        xl: "1280px",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #196

## 📝 작업 내용

> 소셜커뮤니티 전체 페이지 반응형으로 코드 작업했습니다.

## 📌 그외

> RootLayout에 브레이크포인트마다 좌우양옆 마진 설정 해두었습니다.

## 📸 스크린샷 (선택)
