### PR TITLE
🛠️chore : 소셜커뮤니티 상세페이지 댓글 작성 이전 버전으로 되돌리기

### DIFF
--- a/src/pages/community/communityDetail/CommunityDetail.tsx
+++ b/src/pages/community/communityDetail/CommunityDetail.tsx
@@ -4,7 +4,7 @@ import Comments from "./comments/Comments";
 import PostDetail from "./PostDetail";
 import { useParams } from "react-router-dom";
 import ScrollToTopButton from "../../../components/ui/ScrollToTopButton";
-import { PostCardProps } from "../../../types/Post";
+import { PostCardProps } from "../../../types/post";
 
 type PostDetailContent = PostCardProps["post"];
 

--- a/src/pages/community/communityDetail/PostDetail.tsx
+++ b/src/pages/community/communityDetail/PostDetail.tsx
@@ -7,7 +7,7 @@ import api from "../../../api/api";
 import { useModalStore } from "../../../stores/modalStore";
 import { useLikeState } from "../../../hooks/useLikeState";
 import { useAuthStore } from "../../../stores/authStore";
-import { PostCardProps } from "../../../types/Post";
+import { PostCardProps } from "../../../types/post";
 import DOMPurify from "dompurify";
 
 interface PostDetailProps {
@@ -67,7 +67,8 @@ const PostDetail: React.FC<PostDetailProps> = ({
     e.stopPropagation();
     e.preventDefault();
     openModal(
-      "포스트를 삭제하시면 더 이상 볼 수 없습니다.\n정말 삭제 하시겠어요?",
+      `포스트를 삭제하시면 더 이상 볼 수 없습니다.
+      정말 삭제 하시겠어요?`,
       "취소 하기",
       "삭제 하기",
       async () => {
@@ -92,7 +93,8 @@ const PostDetail: React.FC<PostDetailProps> = ({
     if (!isLoggedIn) {
       setIsLoading(false);
       openModal(
-        "로그인이 필요한 서비스입니다.\n로그인 하러 가시겠어요?",
+        `로그인이 필요한 서비스입니다.
+        로그인 하러 가시겠어요?`,
         "취소하기",
         "로그인하기",
         () => navigate("/login")
@@ -127,7 +129,7 @@ const PostDetail: React.FC<PostDetailProps> = ({
             <div className="flex items-center gap-5">
               <div className="flex items-center gap-2">
                 <img
-                  className="w-[30px] h-[30px] rounded-full cursor-pointer"
+                  className="w-[30px] h-[30px] rounded-full cursor-pointer userProfile-shadow"
                   src={postDetail?.userProfileImage || "/default-image.png"}
                   alt="유저프로필 이미지"
                   onClick={handleUserProfileClick}
@@ -156,7 +158,7 @@ const PostDetail: React.FC<PostDetailProps> = ({
                   />
                 </button>
                 {isPostMenuOpen && (
-                  <ul className="w-[114px] h-16 absolute top-[26px] right-2 py-2 px-6 bg-white rounded border border-blue-7 body-small-r text-center">
+                  <ul className="w-[114px] h-16 absolute top-[26px] right-2 py-2 px-4 bg-white rounded border border-blue-7 body-small-r text-center">
                     <li className="mb-2 hover:text-blue-4">
                       <button onClick={handleEditClick}>포스트 수정</button>
                     </li>

--- a/src/pages/community/communityDetail/comments/CommentForm.tsx
+++ b/src/pages/community/communityDetail/comments/CommentForm.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import api from "../../../../api/api";
 import { PostComment } from "../../../../types/comment";
 import { useAuthStore } from "../../../../stores/authStore";
+import ShortButton from "../../../../components/ui/ShortButton";
 
 interface CommentFormProps {
   onSubmit: (comment: PostComment) => void;
@@ -53,27 +54,27 @@ const CommentForm: React.FC<CommentFormProps> = ({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="mb-10">
-      <div className="mb-3">
-        <textarea
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          className="w-full h-[104px] p-4 border border-gray-20 rounded-lg resize-none"
-          placeholder="댓글을 입력하세요"
+    <div className="flex items-end gap-[18px] mb-[60px]">
+      <div className="w-[50px] h-[50px] rounded-full overflow-hidden userProfile-shadow ">
+        <img
+          className="w-full h-full object-cover bg-center"
+          src={user?.s3Bucket || "/default-image.png"}
+          alt="유저 프로필 이미지"
         />
       </div>
-      <div className="flex justify-end">
-        <button
-          type="submit"
-          disabled={isSubmitting || !content.trim()}
-          className={`px-4 py-2 rounded text-white ${
-            isSubmitting || !content.trim() ? "bg-gray-40" : "bg-blue-1"
-          }`}
-        >
-          {isSubmitting ? "등록 중..." : "등록하기"}
-        </button>
-      </div>
-    </form>
+      <form onSubmit={handleSubmit} className="flex items-center gap-6">
+        <div>
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            disabled={isSubmitting}
+            className="w-[907px] h-10 min-h-[40px] border-b border-gray-30 p-2 placeholder:pl-[6px] body-small-r break-words resize-none focus:border-blue-1 focus:placeholder:text-transparent"
+            placeholder="댓글을 입력하세요"
+          />
+        </div>
+        <ShortButton text="댓글 등록" textColor="base-1" bgColor="blue-1" />
+      </form>
+    </div>
   );
 };
 

--- a/src/pages/community/communityDetail/comments/CommentList.tsx
+++ b/src/pages/community/communityDetail/comments/CommentList.tsx
@@ -1,11 +1,11 @@
 import React, { useState, useRef, useEffect } from "react";
-import { formatDate } from "../../../../utils/dateUtils";
 import api from "../../../../api/api";
 import { PostComment } from "../../../../types/comment";
 import { useAuthStore } from "../../../../stores/authStore";
 import { useNavigate } from "react-router-dom";
 import { useModalStore } from "../../../../stores/modalStore";
 import Icon from "../../../../assets/icons/Icon";
+import { formatCommentDate } from "../../../../utils/commentDateUtils";
 
 interface CommentListProps {
   comments: PostComment[];
@@ -14,7 +14,7 @@ interface CommentListProps {
   accessToken: string;
   onCommentUpdate: () => void;
   onCommentDelete: () => void;
-  isLoggedIn?: boolean; // 새로 추가된 prop
+  isLoggedIn?: boolean;
 }
 
 const CommentList: React.FC<CommentListProps> = ({
@@ -24,7 +24,7 @@ const CommentList: React.FC<CommentListProps> = ({
   accessToken,
   onCommentUpdate,
   onCommentDelete,
-  isLoggedIn = false, // 기본값 설정
+  isLoggedIn = false,
 }) => {
   const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
   const [editedContent, setEditedContent] = useState("");
@@ -88,7 +88,8 @@ const CommentList: React.FC<CommentListProps> = ({
   const handleDeleteClick = (commentId: number) => {
     if (!isLoggedIn) {
       openModal(
-        "로그인이 필요한 서비스입니다.\n로그인 하러 가시겠어요?",
+        `로그인이 필요한 서비스입니다.
+        로그인 하러 가시겠어요?`,
         "취소하기",
         "로그인하기",
         () => navigate("/login")
@@ -97,7 +98,8 @@ const CommentList: React.FC<CommentListProps> = ({
     }
 
     openModal(
-      "댓글을 삭제하시면 더 이상 볼 수 없습니다.\n정말 삭제 하시겠어요?",
+      `댓글을 삭제하시면 더 이상 볼 수 없습니다.
+      정말 삭제 하시겠어요?`,
       "취소 하기",
       "삭제 하기",
       async () => {
@@ -132,9 +134,8 @@ const CommentList: React.FC<CommentListProps> = ({
 
   return (
     <div className="commentList">
-      <h3 className="text-blue-4 mb-5">댓글</h3>
       {comments.length === 0 ? (
-        <div className="text-center py-10 text-gray-60">
+        <div className="text-center py-10 text-gray-40">
           첫 번째 댓글을 작성해보세요!
         </div>
       ) : (
@@ -142,55 +143,55 @@ const CommentList: React.FC<CommentListProps> = ({
           {comments.map((comment) => (
             <li
               key={comment.id}
-              className="p-5 border-t border-gray-20 relative"
+              className="p-5 border-b border-gray-30 relative"
             >
               <div className="flex justify-between mb-2.5">
                 <div className="flex items-center gap-2">
                   <div
-                    className="w-[30px] h-[30px] rounded-full overflow-hidden cursor-pointer"
+                    className="w-[25px] h-[25px] rounded-full overflow-hidden userProfile-shadow"
                     onClick={() => handleUserProfileClick(comment.userId)}
                   >
                     <img
-                      src={comment.userProfileImage || "/default-image.png"}
-                      alt="프로필 이미지"
                       className="w-full h-full object-cover bg-center"
+                      src={comment.userProfileImage || "/default-image.png"}
+                      alt="유저프로필이미지"
                     />
                   </div>
-                  <div>
-                    <div
-                      className="font-bold cursor-pointer"
-                      onClick={() => handleUserProfileClick(comment.userId)}
-                    >
-                      {comment.userNickname}
-                    </div>
-                    <div className="text-xs text-gray-60">
-                      {formatDate(comment.createdAt)}
-                    </div>
-                  </div>
+                  <span
+                    className="body-normal-m"
+                    onClick={() => handleUserProfileClick(comment.userId)}
+                  >
+                    {comment.userNickname}
+                  </span>
+                  <span className="caption-r text-gray-30">
+                    {formatCommentDate(comment.createdAt)}
+                  </span>
                 </div>
                 {isLoggedIn && user && user.id === comment.userId && (
                   <div className="relative" ref={menuRef}>
                     <button
                       onClick={() => toggleMenu(comment.id)}
-                      className="text-gray-60"
+                      className="text-blue-2"
                     >
                       <Icon name="EllipsisVertical" size={24} />
                     </button>
                     {menuOpenCommentId === comment.id && (
-                      <div className="absolute right-0 w-24 bg-white border border-gray-20 rounded shadow-md z-10">
+                      <ul className="absolute top-[25px] right-[9px] w-[114px] h-16 py-2 px-4 bg-white rounded border border-blue-7 body-small-r text-center">
                         <button
                           onClick={() => handleEditClick(comment)}
-                          className="block w-full text-left p-2 hover:bg-gray-10"
+                          className="mb-2 hover:text-blue-4"
                         >
                           수정하기
                         </button>
-                        <button
-                          onClick={() => handleDeleteClick(comment.id)}
-                          className="block w-full text-left p-2 hover:bg-gray-10"
-                        >
-                          삭제하기
-                        </button>
-                      </div>
+                        <li>
+                          <button
+                            onClick={() => handleDeleteClick(comment.id)}
+                            className=" hover:text-blue-4"
+                          >
+                            삭제하기
+                          </button>
+                        </li>
+                      </ul>
                     )}
                   </div>
                 )}

--- a/src/pages/community/communityDetail/comments/CommentList.tsx
+++ b/src/pages/community/communityDetail/comments/CommentList.tsx
@@ -148,7 +148,7 @@ const CommentList: React.FC<CommentListProps> = ({
               <div className="flex justify-between mb-2.5">
                 <div className="flex items-center gap-2">
                   <div
-                    className="w-[25px] h-[25px] rounded-full overflow-hidden userProfile-shadow"
+                    className="w-[25px] h-[25px] rounded-full overflow-hidden userProfile-shadow cursor-pointer"
                     onClick={() => handleUserProfileClick(comment.userId)}
                   >
                     <img
@@ -158,7 +158,7 @@ const CommentList: React.FC<CommentListProps> = ({
                     />
                   </div>
                   <span
-                    className="body-normal-m"
+                    className="body-normal-m cursor-pointer"
                     onClick={() => handleUserProfileClick(comment.userId)}
                   >
                     {comment.userNickname}

--- a/src/pages/community/communityDetail/comments/Comments.tsx
+++ b/src/pages/community/communityDetail/comments/Comments.tsx
@@ -121,23 +121,11 @@ const Comments: React.FC<CommentsProps> = ({
 
   return (
     <>
-      {isLoggedIn ? (
-        <CommentForm
-          onSubmit={handleCommentSubmit}
-          socialPostId={socialPostId}
-          accessToken={token || ""}
-        />
-      ) : (
-        <div className="mb-8 text-center p-4 bg-gray-10 rounded-lg">
-          <p className="mb-2">댓글을 작성하려면 로그인이 필요합니다.</p>
-          <button
-            onClick={handleLoginRedirect}
-            className="px-4 py-2 bg-blue-1 text-white rounded hover:bg-blue-2 transition-colors"
-          >
-            로그인하기
-          </button>
-        </div>
-      )}
+      <CommentForm
+        onSubmit={handleCommentSubmit}
+        socialPostId={socialPostId}
+        accessToken={token || ""}
+      />
 
       <CommentList
         comments={comments}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #205

## 📝 작업 내용

> 비로그인 사용자가 커뮤니티 글을 볼 수 있도록 수정하는 과정에서 변경된 댓글 디자인을 원래대로 되돌렸습니다.

## 📌 그외

> 디자인적인 코드만 돌려놓은 상태로 비로그인시 댓글 등록이 안되는 부분의 처리는 기능구현때 할 예정입니다.

## 📸 스크린샷 (선택)
