### PR TITLE
🐛fix : 카카오 맵 중복 렌더링 개선 & typescript 타입 정의 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.18",
     "globals": "^15.15.0",
+    "kakao.maps.d.ts": "^0.1.40",
     "prettier": "^3.5.1",
     "tailwindcss": "3.4.17",
     "typescript": "~5.7.2",

--- a/src/hooks/useKakaoMap.ts
+++ b/src/hooks/useKakaoMap.ts
@@ -1,38 +1,16 @@
-import { useEffect, useRef, useState } from "react";
-
-const KAKAO_APP_KEY = import.meta.env.VITE_APP_KAKAOMAP_KEY;
+import { useRef, useState, useEffect, useCallback } from "react";
 
 export const useKakaoMap = (center: { lat: number; lng: number }) => {
   const container = useRef<HTMLDivElement>(null);
   const mapRef = useRef<any>(null);
-  const markersRef = useRef<any[]>([]);
   const [mapSize, setMapSize] = useState({ width: 1082, height: 560 });
+  const [isMapReady, setIsMapReady] = useState(false);
 
   useEffect(() => {
-    // 화면 크기에 따라 지도 크기 조정
-    // const updateMapSize = () => {
-    //   const width = window.innerWidth;
-    //   if (width >= 1280) {
-    //     setMapSize({ width: 1082, height: 560 });
-    //   } else if (width >= 768) {
-    //     setMapSize({ width: 768, height: 560 });
-    //   } else {
-    //     // 좌우 padding 16px씩 고려, 가로 비율에 맞춰 높이 조정
-    //     setMapSize({
-    //       width: width - 40,
-    //       height: Math.round((width - 32) * 0.52),
-    //     });
-    //   }
-    // };
-    // updateMapSize();
-    // window.addEventListener("resize", updateMapSize);
-    // return () => window.removeEventListener("resize", updateMapSize);
-
     const updateMapSize = () => {
       const width = window.innerWidth;
-      // 원하는 최소/최대값을 설정해도 됨
-      let mapWidth = Math.max(320, Math.min(width - 40, 1082)); // 최소 320, 최대 1082
-      let mapHeight = Math.round(mapWidth * 0.52); // 비율 유지 (원하는 비율로)
+      let mapWidth = Math.max(320, Math.min(width - 40, 1082));
+      let mapHeight = Math.round(mapWidth * 0.52);
       setMapSize({ width: mapWidth, height: mapHeight });
     };
 
@@ -41,51 +19,25 @@ export const useKakaoMap = (center: { lat: number; lng: number }) => {
     return () => window.removeEventListener("resize", updateMapSize);
   }, []);
 
-  useEffect(() => {
-    const loadKakaoMap = () => {
-      if (window.kakao && window.kakao.maps) {
-        window.kakao.maps.load(() => {
-          if (container.current) {
-            const mapOptions = {
-              center: new window.kakao.maps.LatLng(center.lat, center.lng),
-              level: 10,
-            };
-            mapRef.current = new window.kakao.maps.Map(
-              container.current,
-              mapOptions
-            );
-          }
-        });
-      }
-    };
-
-    if (!window.kakao || !window.kakao.maps) {
-      const script = document.createElement("script");
-      script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_APP_KEY}&libraries=services&autoload=false`;
-      script.async = true;
-      script.onload = loadKakaoMap;
-      document.head.appendChild(script);
-    } else {
-      loadKakaoMap();
-    }
-
-    return () => {
-      markersRef.current.forEach((marker) => marker.setMap(null));
-      markersRef.current = [];
-      mapRef.current = null;
-    };
+  // 1) SDK 로드 완료 시 호출
+  const initMap = useCallback(() => {
+    if (!window.kakao || !container.current) return;
+    window.kakao.maps.load(() => {
+      mapRef.current = new window.kakao.maps.Map(container.current!, {
+        center: new window.kakao.maps.LatLng(center.lat, center.lng),
+        level: 10,
+      });
+      setIsMapReady(true);
+    });
   }, [center]);
 
-  // mapSize가 바뀔 때마다 지도 div와 지도 객체에 반영
+  // 2) 지도의 크기 변경 처리
   useEffect(() => {
-    if (container.current) {
-      container.current.style.width = `${mapSize.width}px`;
-      container.current.style.height = `${mapSize.height}px`;
-    }
-    if (mapRef.current) {
-      mapRef.current.relayout();
-    }
+    if (!container.current || !mapRef.current) return;
+    container.current.style.width = `${mapSize.width}px`;
+    container.current.style.height = `${mapSize.height}px`;
+    mapRef.current.relayout();
   }, [mapSize]);
 
-  return { container, mapRef, markersRef };
+  return { container, mapRef, initMap, mapSize, isMapReady };
 };

--- a/src/hooks/useKakaoMap.ts
+++ b/src/hooks/useKakaoMap.ts
@@ -2,7 +2,7 @@ import { useRef, useState, useEffect, useCallback } from "react";
 
 export const useKakaoMap = (center: { lat: number; lng: number }) => {
   const container = useRef<HTMLDivElement>(null);
-  const mapRef = useRef<any>(null);
+  const mapRef = useRef<kakao.maps.Map | null>(null);
   const [mapSize, setMapSize] = useState({ width: 1082, height: 560 });
   const [isMapReady, setIsMapReady] = useState(false);
 
@@ -19,7 +19,6 @@ export const useKakaoMap = (center: { lat: number; lng: number }) => {
     return () => window.removeEventListener("resize", updateMapSize);
   }, []);
 
-  // 1) SDK 로드 완료 시 호출
   const initMap = useCallback(() => {
     if (!window.kakao || !container.current) return;
     window.kakao.maps.load(() => {
@@ -27,11 +26,11 @@ export const useKakaoMap = (center: { lat: number; lng: number }) => {
         center: new window.kakao.maps.LatLng(center.lat, center.lng),
         level: 10,
       });
+      mapRef.current.panBy(0, 0);
       setIsMapReady(true);
     });
   }, [center]);
 
-  // 2) 지도의 크기 변경 처리
   useEffect(() => {
     if (!container.current || !mapRef.current) return;
     container.current.style.width = `${mapSize.width}px`;

--- a/src/hooks/useMapMarkers.ts
+++ b/src/hooks/useMapMarkers.ts
@@ -4,7 +4,8 @@ import { useAddressSearch } from "./useAddressSearch";
 
 export const useMapMarkers = (
   mapRef: React.MutableRefObject<any>,
-  posts?: MapPost[]
+  posts?: MapPost[],
+  isMapReady?: boolean
 ) => {
   const [searchErrors, setSearchErrors] = useState<Record<number, string>>({});
   const markersRef = useRef<any[]>([]);
@@ -124,7 +125,7 @@ export const useMapMarkers = (
   };
 
   useEffect(() => {
-    if (mapRef.current && posts) {
+    if (isMapReady && posts) {
       processPostsLocations();
     }
 
@@ -132,7 +133,7 @@ export const useMapMarkers = (
       markersRef.current.forEach((marker) => marker.setMap(null));
       markersRef.current = [];
     };
-  }, [mapRef.current, posts]);
+  }, [isMapReady, posts]);
 
   return { searchErrors, markersRef };
 };

--- a/src/hooks/useMapMarkers.ts
+++ b/src/hooks/useMapMarkers.ts
@@ -3,12 +3,12 @@ import { MapPost } from "../types/mapSearch";
 import { useAddressSearch } from "./useAddressSearch";
 
 export const useMapMarkers = (
-  mapRef: React.MutableRefObject<any>,
+  mapRef: React.MutableRefObject<kakao.maps.Map | null>,
   posts?: MapPost[],
   isMapReady?: boolean
 ) => {
   const [searchErrors, setSearchErrors] = useState<Record<number, string>>({});
-  const markersRef = useRef<any[]>([]);
+  const markersRef = useRef<kakao.maps.Marker[]>([]);
   const { searchAddress } = useAddressSearch();
 
   // 해시태그 추출 함수
@@ -26,7 +26,7 @@ export const useMapMarkers = (
     const hashtagText = hashtags.join(", ");
 
     return `
-      <div style="padding:10px; font-size:14px; line-height:1.5;">
+      <div style="padding:10px; body-small-r;">
         <strong>${post.description}</strong>
         <p>${hashtagText || "해시태그 없음"}</p>
       </div>
@@ -59,7 +59,7 @@ export const useMapMarkers = (
       const infowindow = new window.kakao.maps.InfoWindow({ content });
 
       window.kakao.maps.event.addListener(marker, "click", () => {
-        infowindow.open(mapRef.current, marker);
+        infowindow.open(mapRef.current!, marker);
       });
 
       markersRef.current.push(marker);
@@ -105,11 +105,11 @@ export const useMapMarkers = (
           });
 
           const infowindow = new window.kakao.maps.InfoWindow({
-            content: `<div style="padding:5px;font-size:12px;">${post.title}</div>`,
+            content: `<div style="padding:5px; font-size:12px;">${post.title}</div>`,
           });
 
           window.kakao.maps.event.addListener(marker, "click", () => {
-            infowindow.open(mapRef.current, marker);
+            infowindow.open(mapRef.current!, marker);
           });
 
           markersRef.current.push(marker);

--- a/src/pages/mapsearch/Map.tsx
+++ b/src/pages/mapsearch/Map.tsx
@@ -7,7 +7,7 @@ const KAKAO_APP_KEY = import.meta.env.VITE_APP_KAKAOMAP_KEY;
 
 declare global {
   interface Window {
-    kakao: any;
+    kakao: typeof kakao;
   }
 }
 interface MapProps {
@@ -35,7 +35,6 @@ const Map = ({ center, posts }: MapProps) => {
             height: `${mapSize.height}px`,
           }}
         ></div>
-
         {Object.keys(searchErrors).length > 0 && (
           <p className="caption-r text-red mt-[15px] text-center">
             일부 위치를 찾을 수 없습니다.

--- a/src/pages/mapsearch/Map.tsx
+++ b/src/pages/mapsearch/Map.tsx
@@ -16,21 +16,25 @@ interface MapProps {
 }
 
 const Map = ({ center, posts }: MapProps) => {
-  // 카카오맵 초기화 및 기본 설정을 위한 커스텀 훅 사용
-  const { container, mapRef } = useKakaoMap(center);
-
-  // 마커 관리 및 표시를 위한 커스텀 훅 사용
-  const { searchErrors } = useMapMarkers(mapRef, posts);
+  const { container, initMap, mapRef, mapSize, isMapReady } =
+    useKakaoMap(center);
+  const { searchErrors } = useMapMarkers(mapRef, posts, isMapReady);
 
   return (
     <div>
       <Script
         async
         src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_APP_KEY}&libraries=services&autoload=false`}
+        onLoad={initMap}
       />
-
       <div className="flex flex-col items-center justify-center w-full">
-        <div ref={container}></div>
+        <div
+          ref={container}
+          style={{
+            width: `${mapSize.width}px`,
+            height: `${mapSize.height}px`,
+          }}
+        ></div>
 
         {Object.keys(searchErrors).length > 0 && (
           <p className="caption-r text-red mt-[15px] text-center">

--- a/src/types/mapSearch.ts
+++ b/src/types/mapSearch.ts
@@ -26,8 +26,8 @@ export interface MapPost {
   detailImage: string;
   description: string;
   bookmarked: boolean;
-  latitude?: number;
-  longitude?: number;
+  latitude: number;
+  longitude: number;
   category: string;
   apiCategory?: string;
 }

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,7 +20,9 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+
+    "types": ["kakao.maps.d.ts"]
   },
   "include": ["src"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2164,6 +2164,11 @@ json5@^2.2.3:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
+kakao.maps.d.ts@^0.1.40:
+  version "0.1.40"
+  resolved "https://registry.yarnpkg.com/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.40.tgz#60a922e6fa1ab90c57e062e84978eb2d0e506412"
+  integrity sha512-nX69MB1ok04epe3OqS+/tEeWBbU31GSQbvDPJmQRRltzzqn6t4jBsO5v1nzalUjCKzwcH2CptOc767NZ7Hbu3g==
+
 keyv@^4.5.4:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #193 

## 📝 작업 내용

> 카카오 맵을 확대 및 축소, 이동할 때 지도가 중복으로 생성되는 부분을 수정했습니다. 

> * **중복생성 원인** 
Map.tsx의 script가 로드되지 못하는 경우 useKakaoMap.ts 내 지도인스턴스 초기화 코드의 script로 로드하게 되어있었기에 지도인스턴스가 중복으로 생성되었던 것입니다. 

>  * **개선방안**
지도 초기화를 Map.tsx 내의 script에서 initMap을 통해 한번만 하도록 했고 useKakaoMap.ts 내에서 script 로드가 완료 되었을 때 지도를 호출 할 수 있도록 코드를 개선했습니다. 

## 📌 그외

> kakao.maps.d.ts 로 any로 작성했던 카카오맵 타입을 수정했습니다. 
 
## 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/985ec696-e9fa-4c6d-a0fb-311f897ecd20)
![image](https://github.com/user-attachments/assets/6c56d171-42fe-45d2-99b3-c24bd79cd99f)
